### PR TITLE
Adding missing "centi", "deci", "deca" and "hecto" SI prefixes

### DIFF
--- a/measurement/base.py
+++ b/measurement/base.py
@@ -62,10 +62,10 @@ class MeasureBase(object):
         'nano': 'n',
         'micro': 'u',
         'milli': 'm',
-        'centi': 'c'
-        'deci': 'd'
-        'deca': 'da'
-        'hecto': 'h'
+        'centi': 'c',
+        'deci': 'd',
+        'deca': 'da',
+        'hecto': 'h',
         'kilo': 'k',
         'mega': 'M',
         'giga': 'G',


### PR DESCRIPTION
Hello,
I was surprised that four SI prefixes were missing, so I suggest to add them if there is no good reason to let them appart.
I did not fully test the changes but it should be fine like this. I don't think any other changes are required, except for the doc which I can edit later if you accept the pull request (unless you generate the "allowed as attributes and arguments" lists automatically).

regards,
Luc

edit : reference for SI metric prefixes -> http://en.wikipedia.org/wiki/Metric_prefix
