### PR TITLE
Updated to optionally allow Decimal usage without affecting django-measurement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,20 +16,20 @@ objects, but also other measurements including:
 - Temperature
 - Time
 - Volume
-- Weight
+- Mass
 
 Example:
 
 .. code-block:: python
 
-   >>> from measurement.measures import Weight
-   >>> weight_1 = Weight(lb=125)
-   >>> weight_2 = Weight(kg=40)
+   >>> from measurement.measures import Mass
+   >>> mass_1 = Mass(lb=125)
+   >>> mass_2 = Mass(kg=40)
    >>> added_together = weight_1 + weight_2
    >>> added_together
-   Weight(lb=213.184976807)
+   Mass(lb=213.184976807)
    >>> added_together.kg  # Maybe I actually need this value in kg?
-   96.699
+   96.69904625
 
 .. warning::
    Measurements are stored internally by converting them to a
@@ -39,6 +39,18 @@ Example:
 
    TLDR: Do not use this in
    `navigation algorithms guiding probes into the atmosphere of extraterrestrial worlds <http://en.wikipedia.org/wiki/Mars_Climate_Orbiter>`_.
+
+    Optionally, measurements can use
+    Decimal values internally by setting the decimal parameter to True.
+
+    Example:
+
+    .. code-block:: python
+
+       >>> from measurement.measures import Mass
+       >>> mass = Mass(lb=125, decimal=True)
+       >>> mass.kg
+       Decimal('56.69904625')
 
 - Documentation for python-measurement is available an
   `ReadTheDocs <https://python-measurement.readthedocs.org/>`_.

--- a/docs/topics/creating_your_own_class.rst
+++ b/docs/topics/creating_your_own_class.rst
@@ -17,30 +17,32 @@ A simple example is Weight:
 
 .. code-block:: python
 
+   from decimal import Decimal
    from measurement.base import MeasureBase
 
+
    class Weight(MeasureBase):
-       STANDARD_UNIT = 'g'
+       STANDARD_UNIT = "g"
        UNITS = {
-           'g': 1.0,
-           'tonne': 1000000.0,
-           'oz': 28.3495,
-           'lb': 453.592,
-           'stone': 6350.29,
-           'short_ton': 907185.0,
-           'long_ton': 1016000.0,
+           "g": Decimal("1.0"),
+           "tonne": Decimal("1000000.0"),
+           "oz": Decimal("28.3495"),
+           "lb": Decimal("453.592"),
+           "stone": Decimal("6350.29"),
+           "short_ton": Decimal("907185.0"),
+           "long_ton": Decimal("1016000.0"),
        }
        ALIAS = {
-           'gram': 'g',
-           'ton': 'short_ton',
-           'metric tonne': 'tonne',
-           'metric ton': 'tonne',
-           'ounce': 'oz',
-           'pound': 'lb',
-           'short ton': 'short_ton',
-           'long ton': 'long_ton',
+           "gram": "g",
+           "ton": "short_ton",
+           "metric tonne": "tonne",
+           "metric ton": "tonne",
+           "ounce": "oz",
+           "pound": "lb",
+           "short ton": "short_ton",
+           "long ton": "long_ton",
        }
-       SI_UNITS = ['g']
+       SI_UNITS = ["g"]
 
 Important details:
 
@@ -73,21 +75,22 @@ your measure's standard unit and the unit you're defining:
 
 .. code-block:: python
 
+   from decimal import Decimal
    from sympy import S, Symbol
    from measurement.base import MeasureBase
 
    class Temperature(MeasureBase):
-       SU = Symbol('kelvin')
-       STANDARD_UNIT = 'k'
+       SU = Symbol("kelvin")
+       STANDARD_UNIT = "k"
        UNITS = {
-           'c': SU - S(273.15),
-           'f': (SU - S(273.15)) * S('9/5') + 32,
-           'k': 1.0
+           "c": SU - S(273.15),
+           "f": (SU - S(273.15)) * S("9/5") + 32,
+           "k": Decimal("1.0")
        }
        ALIAS = {
-           'celsius': 'c',
-           'fahrenheit': 'f',
-           'kelvin': 'k',
+           "celsius": "c",
+           "fahrenheit": "f",
+           "kelvin": "k",
        }
 
 Important details:

--- a/docs/topics/measures.rst
+++ b/docs/topics/measures.rst
@@ -36,7 +36,7 @@ This application provides the following measures:
       >>> unit = 'U.S. Foot'
       >>> value = 10
       >>> measurement = guess(value, unit)
-      >>> print measurement
+      >>> print(measurement)
       10.0 U.S. Foot
 
 
@@ -74,9 +74,9 @@ Speed
 
       >>> from measurement.measure import Speed
       >>> my_speed = Speed(mile__hour=24)
-      >>> print my_speed
+      >>> print(my_speed)
       24.0 mi/hr
-      >>> print my_speed.km__hr
+      >>> print(my_speed.km__hr)
       38.624256
 
 * *Primary Measurement*: Distance
@@ -100,12 +100,12 @@ Temperature
 
       >>> temperatures = [Temperature(c=10), Temperature(c=20)]
       >>> average = sum(temperatures, Temperature(k=0)) / len(temperatures)
-      >>> print average  # The value will be shown in Kelvin by default since that is the starting unit
+      >>> print(average)  # The value will be shown in Kelvin by default since that is the starting unit
       288.15 k
-      >>> print average.c  # But, you can easily get the Celsius value
+      >>> print(average.c)  # But, you can easily get the Celsius value
       15.0
       >>> average.unit = 'c'  # Or, make the measurement report its value in Celsius by default
-      >>> print average
+      >>> print(average)
       15.0 c
 
 Time

--- a/docs/topics/use.rst
+++ b/docs/topics/use.rst
@@ -5,21 +5,32 @@ Using Measurement Objects
 You can import any of the above measures from `measurement.measures` 
 and use it for easily handling measurements like so::
 
-    >>> from measurement.measures import Weight
-    >>> w = Weight(lb=135) # Represents 135lbs
-    >>> print w
+    >>> from measurement.measures import Mass
+    >>> m = Mass(lb=135) # Represents 135lbs
+    >>> print(m)
     135.0 lb
-    >>> print w.kg
-    61.234919999999995
+    >>> print(m.long_ton)
+    0.06027063971456693
 
 You can create a measurement unit using any compatible unit and can transform
 it into any compatible unit.  See :doc:`measures` for information about which
 units are supported by which measures.
 
+By default, measures are stored as float values. For higher precision, you can 
+use decimals by setting the optional decimal argument to True. To do this, the 
+example above becomes::
+
+    >>> from measurement.measures import Mass
+    >>> m = Mass(lb=135, decimal=True) # Represents 135lbs
+    >>> print(m)
+    135 lb
+    >>> print(m.long_ton)
+    0.06027063971456692913385826772
+
 To access the raw integer value of a measurement in the unit it was defined in,
 you can use the 'value' property::
 
-    >>> print w.value
+    >>> print(w.value)
     135.0
 
 
@@ -32,8 +43,8 @@ use the `guess` function to give you a measurement object.::
 
     >>> from measurement.utils import guess
     >>> m = guess(10, 'mg')
-    >>> print repr(m)
-    Weight(mg=10.0)
+    >>> print(repr(m))
+    Mass(mg=10.0)
 
 By default, this will check all built-in measures, and will return the first
 measure having an appropriate unit.  You may want to constrain the list of
@@ -43,7 +54,7 @@ the ``measures`` keyword argument::
 
     >>> from measurement.measures import Distance, Temperature, Volume
     >>> m = guess(24, 'f', measures=[Distance, Volume, Temperature])
-    >>> print repr(m)
+    >>> print(repr(m))
     Temperature(f=24)
 
 .. warning::

--- a/measurement/measures/capacitance.py
+++ b/measurement/measures/capacitance.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Capacitance"]
@@ -5,9 +7,7 @@ __all__ = ["Capacitance"]
 
 class Capacitance(MeasureBase):
     STANDARD_UNIT = "F"
-    UNITS = {
-        "F": 1.0,
-    }
+    UNITS = {"F": Decimal("1.0")}
     ALIAS = {
         "farad": "F",
     }

--- a/measurement/measures/current.py
+++ b/measurement/measures/current.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Current"]
@@ -5,9 +7,7 @@ __all__ = ["Current"]
 
 class Current(MeasureBase):
     STANDARD_UNIT = "A"
-    UNITS = {
-        "A": 1.0,
-    }
+    UNITS = {"A": Decimal("1.0")}
     ALIAS = {
         "amp": "A",
         "ampere": "A",

--- a/measurement/measures/distance.py
+++ b/measurement/measures/distance.py
@@ -34,6 +34,8 @@ Authors: Robert Coup, Justin Bronn, Riccardo Di Virgilio
 Inspired by GeoPy (http://exogen.case.edu/projects/geopy/)
 and Geoff Biggs' PhD work on dimensioned units for robotics.
 """
+from decimal import Decimal
+
 from measurement.base import NUMERIC_TYPES, MeasureBase, pretty_name
 
 __all__ = [
@@ -48,32 +50,33 @@ AREA_PREFIX = "sq_"
 class Distance(MeasureBase):
     STANDARD_UNIT = "m"
     UNITS = {
-        "chain": 20.1168,
-        "chain_benoit": 20.116782,
-        "chain_sears": 20.1167645,
-        "british_chain_benoit": 20.1167824944,
-        "british_chain_sears": 20.1167651216,
-        "british_chain_sears_truncated": 20.116756,
-        "british_ft": 0.304799471539,
-        "british_yd": 0.914398414616,
-        "clarke_ft": 0.3047972654,
-        "clarke_link": 0.201166195164,
-        "fathom": 1.8288,
-        "ft": 0.3048,
-        "german_m": 1.0000135965,
-        "gold_coast_ft": 0.304799710181508,
-        "indian_yd": 0.914398530744,
-        "inch": 0.0254,
-        "link": 0.201168,
-        "link_benoit": 0.20116782,
-        "link_sears": 0.20116765,
-        "m": 1.0,
-        "mi": 1609.344,
-        "nm_uk": 1853.184,
-        "rod": 5.0292,
-        "sears_yd": 0.91439841,
-        "survey_ft": 0.304800609601,
-        "yd": 0.9144,
+        "chain": Decimal("20.1168"),
+        "chain_benoit": Decimal("20.116782"),
+        "chain_sears": Decimal("20.1167645"),
+        "british_chain_benoit": Decimal("20.1167824944"),
+        "british_chain_sears": Decimal("20.1167651216"),
+        "british_chain_sears_truncated": Decimal("20.116756"),
+        "british_ft": Decimal("0.304799471539"),
+        "british_yd": Decimal("0.914398414616"),
+        "clarke_ft": Decimal("0.3047972654"),
+        "clarke_link": Decimal("0.201166195164"),
+        "fathom": Decimal("1.8288"),
+        "ft": Decimal("0.3048"),
+        "german_m": Decimal("1.0000135965"),
+        "gold_coast_ft": Decimal("0.304799710181508"),
+        "indian_yd": Decimal("0.914398530744"),
+        "inch": Decimal("0.0254"),
+        "link": Decimal("0.201168"),
+        "link_benoit": Decimal("0.20116782"),
+        "link_sears": Decimal("0.20116765"),
+        "m": Decimal("1.0000"),
+        "mi": Decimal("1609.34400"),
+        "nm": Decimal("1851.9993"),
+        "nm_uk": Decimal("1853.18400"),
+        "rod": Decimal("5.02920"),
+        "sears_yd": Decimal("0.91439841"),
+        "survey_ft": Decimal("0.304800609601"),
+        "yd": Decimal("0.91440"),
     }
     SI_UNITS = ["m"]
 
@@ -134,8 +137,8 @@ class Area(MeasureBase):
     # Getting the square units values and the alias dictionary.
     UNITS = {
         **{"%s%s" % (AREA_PREFIX, k): v ** 2 for k, v in Distance.get_units().items()},
-        "acre": 43560 * (Distance(ft=1).m ** 2),
-        "hectare": (10000),  # 10,000 sq_m
+        "acre": Decimal("43560") * (Decimal(Distance(ft="1.0").m) ** 2),
+        "hectare": Decimal("10000"),  # 10,000 sq_m
     }
     ALIAS = {
         **{k: "%s%s" % (AREA_PREFIX, v) for k, v in Distance.get_aliases().items()},

--- a/measurement/measures/energy.py
+++ b/measurement/measures/energy.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Energy"]
@@ -6,11 +8,11 @@ __all__ = ["Energy"]
 class Energy(MeasureBase):
     STANDARD_UNIT = "J"
     UNITS = {
-        "c": 4.18400,
-        "C": 4184.0,
-        "J": 1.0,
-        "eV": 1.602177e-19,
-        "tonne_tnt": 4184000000,
+        "c": Decimal("4.18400"),
+        "C": Decimal("4184.0"),
+        "J": Decimal("1.0"),
+        "eV": Decimal("1.602177e-19"),
+        "tonne_tnt": Decimal("4184000000"),
     }
     ALIAS = {
         "joule": "J",

--- a/measurement/measures/frequency.py
+++ b/measurement/measures/frequency.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Frequency"]
@@ -5,10 +7,7 @@ __all__ = ["Frequency"]
 
 class Frequency(MeasureBase):
     STANDARD_UNIT = "Hz"
-    UNITS = {
-        "Hz": 1.0,
-        "rpm": 1.0 / 60,
-    }
+    UNITS = {"Hz": Decimal("1.0"), "rpm": Decimal(1.0 / 60)}
     ALIAS = {
         "hertz": "Hz",
     }

--- a/measurement/measures/mass.py
+++ b/measurement/measures/mass.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = [
@@ -9,13 +11,13 @@ __all__ = [
 class Mass(MeasureBase):
     STANDARD_UNIT = "g"
     UNITS = {
-        "g": 1.0,
-        "tonne": 1000000.0,
-        "oz": 28.3495,
-        "lb": 453.592,
-        "stone": 6350.29,
-        "short_ton": 907185.0,
-        "long_ton": 1016000.0,
+        "g": Decimal("1.0"),
+        "tonne": Decimal("1000000.0"),
+        "oz": Decimal("28.34952"),
+        "lb": Decimal("453.59237"),
+        "stone": Decimal("6350.293"),
+        "short_ton": Decimal("907185.0"),
+        "long_ton": Decimal("1016000.0"),
     }
     ALIAS = {
         "mcg": "ug",

--- a/measurement/measures/pressure.py
+++ b/measurement/measures/pressure.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Pressure"]
@@ -8,12 +10,12 @@ class Pressure(MeasureBase):
 
     STANDARD_UNIT = "pa"
     UNITS = {
-        "pa": 1.0,
-        "bar": 100000,
-        "at": 98066.5,
-        "atm": 101325,
-        "torr": 133.322,
-        "psi": 6894.757293168,
+        "pa": Decimal("1.0"),
+        "bar": Decimal("100000"),
+        "at": Decimal("98066.5"),
+        "atm": Decimal("101325"),
+        "torr": Decimal("133.322"),
+        "psi": Decimal("6894.757293168"),
     }
     ALIAS = {
         "pascal": "pa",

--- a/measurement/measures/radioactivity.py
+++ b/measurement/measures/radioactivity.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Radioactivity"]
@@ -8,10 +10,10 @@ class Radioactivity(MeasureBase):
 
     STANDARD_UNIT = "bq"
     UNITS = {
-        "bq": 1,
-        "ci": 37000000000,
-        "rd": 1000000,
-        "dpm": 1 / 60,
+        "bq": Decimal("1"),
+        "ci": Decimal("37000000000"),
+        "rd": Decimal("1000000"),
+        "dpm": Decimal("1") / Decimal("60"),
     }
     ALIAS = {
         "becquerel": "bq",

--- a/measurement/measures/resistance.py
+++ b/measurement/measures/resistance.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Resistance"]
@@ -5,8 +7,6 @@ __all__ = ["Resistance"]
 
 class Resistance(MeasureBase):
     STANDARD_UNIT = "ohm"
-    UNITS = {
-        "ohm": 1.0,
-    }
+    UNITS = {"ohm": Decimal("1.0")}
     ALIAS = {}
     SI_UNITS = ["ohm"]

--- a/measurement/measures/speed.py
+++ b/measurement/measures/speed.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import BidimensionalMeasure
 from measurement.measures.distance import Distance
 from measurement.measures.time import Time

--- a/measurement/measures/temperature.py
+++ b/measurement/measures/temperature.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from sympy import S, Symbol
 
 from measurement.base import MeasureBase
@@ -8,7 +10,11 @@ __all__ = ["Temperature"]
 class Temperature(MeasureBase):
     SU = Symbol("kelvin")
     STANDARD_UNIT = "k"
-    UNITS = {"c": SU - S(273.15), "f": (SU - S(273.15)) * S("9/5") + 32, "k": 1.0}
+    UNITS = {
+        "c": SU - S(273.15),
+        "f": (SU - S(273.15)) * S("9/5") + 32,
+        "k": Decimal("1.0"),
+    }
     ALIAS = {
         "celsius": "c",
         "fahrenheit": "f",

--- a/measurement/measures/time.py
+++ b/measurement/measures/time.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = [
@@ -15,7 +17,12 @@ class Time(MeasureBase):
     """
 
     STANDARD_UNIT = "s"
-    UNITS = {"s": 1.0, "min": 60.0, "hr": 3600.0, "day": 86400.0}
+    UNITS = {
+        "s": Decimal("1.0"),
+        "min": Decimal("60.0"),
+        "hr": Decimal("3600.0"),
+        "day": Decimal("86400.0"),
+    }
     ALIAS = {
         "second": "s",
         "sec": "s",  # For backward compatibility

--- a/measurement/measures/voltage.py
+++ b/measurement/measures/voltage.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = ["Voltage"]
@@ -5,6 +7,6 @@ __all__ = ["Voltage"]
 
 class Voltage(MeasureBase):
     STANDARD_UNIT = "V"
-    UNITS = {"V": 1.0}
+    UNITS = {"V": Decimal("1.0")}
     ALIAS = {"volt": "V"}
     SI_UNITS = ["V"]

--- a/measurement/measures/volume.py
+++ b/measurement/measures/volume.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from measurement.base import MeasureBase
 
 __all__ = [
@@ -8,30 +10,30 @@ __all__ = [
 class Volume(MeasureBase):
     STANDARD_UNIT = "cubic_meter"
     UNITS = {
-        "us_g": 0.00378541,
-        "mil_us_g": 3785.41,
-        "us_qt": 0.000946353,
-        "us_pint": 0.000473176,
-        "us_cup": 0.000236588,
-        "us_oz": 2.9574e-5,
-        "us_tbsp": 1.4787e-5,
-        "us_tsp": 4.9289e-6,
-        "cubic_millimeter": 0.000000001,
-        "cubic_centimeter": 0.000001,
-        "cubic_decimeter": 0.001,
-        "cubic_meter": 1.0,
-        "l": 0.001,
-        "cubic_foot": 0.0283168,
-        "cubic_inch": 1.6387e-5,
-        "cubic_yard": 0.76455486121558,
-        "imperial_g": 0.00454609,
-        "imperial_qt": 0.00113652,
-        "imperial_pint": 0.000568261,
-        "imperial_oz": 2.8413e-5,
-        "imperial_tbsp": 1.7758e-5,
-        "imperial_tsp": 5.9194e-6,
-        "acre_in": 102.79015461,
-        "acre_ft": 1233.48185532,
+        "us_g": Decimal("0.00378541"),
+        "mil_us_g": Decimal("3785.41"),
+        "us_qt": Decimal("0.000946353"),
+        "us_pint": Decimal("0.000473176"),
+        "us_cup": Decimal("0.000236588"),
+        "us_oz": Decimal("2.9574e-5"),
+        "us_tbsp": Decimal("1.4787e-5"),
+        "us_tsp": Decimal("4.9289e-6"),
+        "cubic_millimeter": Decimal("0.000000001"),
+        "cubic_centimeter": Decimal("0.000001"),
+        "cubic_decimeter": Decimal("0.001"),
+        "cubic_meter": Decimal("1.0"),
+        "l": Decimal("0.001"),
+        "cubic_foot": Decimal("0.0283168"),
+        "cubic_inch": Decimal("1.6387e-5"),
+        "cubic_yard": Decimal("0.76455486121558"),
+        "imperial_g": Decimal("0.00454609"),
+        "imperial_qt": Decimal("0.00113652"),
+        "imperial_pint": Decimal("0.000568261"),
+        "imperial_oz": Decimal("2.8413e-5"),
+        "imperial_tbsp": Decimal("1.7758e-5"),
+        "imperial_tsp": Decimal("5.9194e-6"),
+        "acre_in": Decimal("102.79015461"),
+        "acre_ft": Decimal("1233.48185532"),
     }
     ALIAS = {
         "US Gallon": "us_g",

--- a/measurement/utils.py
+++ b/measurement/utils.py
@@ -1,8 +1,8 @@
 import inspect
+from measurement import measures
 
 
 def get_all_measures():
-    from measurement import measures
 
     m = []
     for name, obj in inspect.getmembers(measures):
@@ -10,13 +10,12 @@ def get_all_measures():
             m.append(obj)
     return m
 
-
-def guess(value, unit, measures=None):
+def guess(value, unit, measures=None, decimal=False):
     if measures is None:
         measures = get_all_measures()
     for measure in measures:
         try:
-            return measure(**{unit: value})
+            return measure(**{unit: value}, decimal=decimal)
         except AttributeError:
             pass
     raise ValueError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ test = pytest
 [tool:pytest]
 addopts =
     --cov=measurement
+    --capture=no
 
 [build_sphinx]
 source-dir = docs

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from decimal import Decimal
 from measurement.measures import Area, Distance
 
 from .base import MeasurementTestBase
@@ -55,4 +56,67 @@ class DistanceTest(MeasurementTestBase):
         distance.value = 11
 
         expected_standard = 17702.784
+        self.assertEqual(distance.standard, expected_standard)
+
+    def test_conversion_equivalence_decimal(self):
+        miles = Distance(mi="1.0", decimal=True)
+        kilometers = Distance(km="1.609344", decimal=True)
+
+        print("test_conversion_equivalence_decimal", miles.km, kilometers.km)
+
+        self.assertAlmostEqual(miles.km, kilometers.km)
+
+    def test_attrib_conversion_decimal(self):
+        kilometers = Distance(km="1.0", decimal=True)
+        expected_meters = Decimal("1000")
+
+        print("test_attrib_conversion_decimal", kilometers.m, expected_meters)
+
+        self.assertAlmostEqual(kilometers.m, expected_meters)
+
+    def test_identity_conversion_decimal(self):
+        miles = Distance(mi="10", decimal=True)
+        expected_miles = Decimal("10")
+
+        print("test_identity_conversion_decimal", miles.mi, expected_miles)
+
+        self.assertAlmostEqual(miles.mi, expected_miles)
+
+    def test_auto_si_kwargs_decimal(self):
+        meters = Distance(meter="1e6", decimal=True)
+        megameters = Distance(megameter="1", decimal=True)
+
+        print("test_auto_si_kwargs_decimal", meters, megameters)
+
+        self.assertEqual(meters, megameters)
+
+    def test_auto_si_attrs_decimal(self):
+        one_meter = Distance(m="1", decimal=True)
+        micrometers = one_meter.um
+
+        print("test_auto_si_attrs_decimal", one_meter.value * 10 ** 6, micrometers)
+
+        self.assertEqual(one_meter.value * 10 ** 6, micrometers)
+
+    def test_area_sq_km_decimal(self):
+        one_sq_km = Area(sq_km="10", decimal=True)
+        miles_sqd = Area(sq_mi="3.8610215854244585", decimal=True)
+
+        print("test_area_sq_km_decimal", one_sq_km.standard, miles_sqd.standard)
+
+        self.assertAlmostEqual(one_sq_km.standard, miles_sqd.standard, places=9)
+
+    def test_set_value_decimal(self):
+        distance = Distance(mi="10", decimal=True)
+        expected_standard = Decimal("16093.44")
+
+        print("test_set_value_decimal", distance.standard, expected_standard)
+
+        self.assertEqual(distance.standard, expected_standard)
+
+        distance.value = Decimal("11")
+        expected_standard = Decimal("17702.784")
+
+        print("test_set_value_decimal part 2", distance.standard, expected_standard)
+
         self.assertEqual(distance.standard, expected_standard)

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -8,6 +8,13 @@ class EnergyTest(MeasurementTestBase):
         calories = Energy(Calorie=2000)
         kilojoules = Energy(kJ=8368)
 
-        self.assertEqual(
-            calories.standard, kilojoules.standard,
-        )
+        self.assertEqual(calories.standard, kilojoules.standard)
+
+
+    def test_dietary_calories_kwarg_decimal(self):
+        calories = Energy(Calorie="2000", decimal=True)
+        kilojoules = Energy(kJ="8368", decimal=True)
+
+        print("test_dietary_calories_kwarg_decimal", calories.standard, kilojoules.standard)
+
+        self.assertEqual(calories.standard, kilojoules.standard)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -9,3 +9,12 @@ class VolumeTest(MeasurementTestBase):
         fl_oz = Volume(us_oz=6.76280454)
 
         self.assertAlmostEqual(milliliters.standard, fl_oz.standard)
+
+
+    def test_sub_one_base_si_measure_decimal(self):
+        milliliters = Volume(ml="200", decimal=True)
+        fl_oz = Volume(us_oz="6.76280454", decimal=True)
+
+        print("test_sub_one_base_si_measure_decimal", milliliters.standard, fl_oz.standard)
+
+        self.assertAlmostEqual(milliliters.standard, fl_oz.standard)


### PR DESCRIPTION
Updated to use use Decimal values if provided with the optional 'decimal' parameter.

```
>>> from measurement.measures import *
>>> m = Mass(lb=135)
>>> m2 = Mass(lb=135, decimal=True)
>>> print(m)
135.0 lb
>>> print(m2)
135 lb
>>> print(repr(m.long_ton))
0.06027063971456693
>>> print(repr(m2.long_ton))
Decimal('0.06027063971456692913385826772')
```

Works flawlessly with django-measurement as-is (though I'm working toward a PR that will allow django-measurement to use this new decimal functionality as well). In the process, also updated the docs to mention Decimal and to correct Python 2 style print statements.

Based partially on work initially proposed by @soba.