### PR TITLE
Fix #40 -- Raise type error with proper message

### DIFF
--- a/measurement/base.py
+++ b/measurement/base.py
@@ -339,11 +339,11 @@ class AbstractMeasure(metaclass=MeasureBase):
     def __mul__(self, other):
         try:
             value = getattr(self, self.unit.org_name) * other
+            return type(self)(value=value, unit=self.unit.org_name)
         except TypeError as e:
             raise TypeError(
                 f"can't multiply type '{qualname(self)}' and '{qualname(other)}'"
             ) from e
-        return type(self)(value=value, unit=self.unit.org_name)
 
     def __imul__(self, other):
         return self * other

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,7 +3,7 @@ import decimal
 import pytest
 
 from measurement.base import ImmutableKeyDict, MetricUnit, Unit, qualname
-from measurement.measures import Distance
+from measurement.measures import Distance, Mass
 
 
 def test_qualname():
@@ -164,6 +164,11 @@ class TestAbstractMeasure:
         assert (
             str(e.value) == f"can't multiply type '{qualname(self.measure)}' and 'str'"
         )
+
+    def test_mul__raise_for_same_type(self):
+        with pytest.raises(TypeError) as e:
+            Mass("1 kg") * Mass("1 kg")
+        assert str(e.value) == f"can't multiply type 'Mass' and 'Mass'"
 
     def test_imul(self):
         d = self.measure(**{self.unit: 2})


### PR DESCRIPTION
If two measures are multiplied that are not compatible – should
not be multipled, like mass x mass -, the error message should
indicate that incompatibility.