### PR TITLE
updated the organic name when creating the object

### DIFF
--- a/measurement/base.py
+++ b/measurement/base.py
@@ -5,6 +5,7 @@ import decimal
 import inspect
 import warnings
 from functools import total_ordering
+from math import floor, log10
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 
@@ -257,6 +258,20 @@ class AbstractMeasure(metaclass=MeasureBase):
         self.unit = self._units[unit]
         self.unit.org_name = unit
         self.si_value = self.unit.to_si(value)
+        self.units_conversor = { float(v.factor):k for k,v in self._units.items() if len(k) <= 3 }
+        self.update_org_name()
+    
+    def update_org_name(self):
+        if self.si_value == 0:
+            self.unit.org_name = self.units_conversor[1.0]
+        else:
+            factor = float(10**int((floor(log10(self.si_value)/3)*3)))
+            if factor in self.units_conversor:
+                self.unit.org_name = self.units_conversor[factor]
+            elif factor > max(self.units_conversor):
+                self.unit.org_name = self.units_conversor[max(self.units_conversor)] 
+            elif factor < min(self.units_conversor):
+                self.unit.org_name = self.units_conversor[min(self.units_conversor)] 
 
     def __getattr__(self, name):
         try:


### PR DESCRIPTION
updated the organic name when creating the object

Now when you create a measurement object the unit is converted to the most optimal
for example, if you declare Capacitance('0.0001 F'), it returns the object Capacitance('100 uF')

I recommend calling the function self.update_org_name() after calculations or before printing the value on the screen