### PR TITLE
Add base unit

### DIFF
--- a/measurement/base.py
+++ b/measurement/base.py
@@ -32,7 +32,7 @@ class AbstractUnit(abc.ABC):
     """
     Helper class to define units of measurement in relation to their SI definition.
 
-    Nowerdays all units of measurement are defined based on fundamental SI units.
+    Nowadays all units of measurement are defined based on fundamental SI units.
     This class provides behavior to convert a SI unit based measure to another Unit.
     """
 
@@ -65,10 +65,10 @@ class Unit(AbstractUnit):
 
 
         class Distance(AbstractMeasure):
-            metre = Unit("1", ['m', 'meter'])
+            metre = Unit("1", ["m", "meter"])
             inch = Unit("0.0254", ["in", "inches"])
 
-    In the example aboce we implemented a simple distance measure. This first
+    In the example above we implemented a simple distance measure. This first
     argument of a unit is it's SI unit factor. For the SI unit itself –
     in this example metre – it's "1". For inches, the factor is by which number
     you would need to multiple a meter to get to an inch. Or, 0.0254 metres make
@@ -77,7 +77,10 @@ class Unit(AbstractUnit):
     The second argument is a list of symbols, that are used to describe the unit.
     In the case of a metre, it is ``m`` and also the American English `meter`.
     Note that the attribute name itself, will also be added automatically to
-    the list of symboles.
+    the list of symbols.
+
+    In a real-world measure, meter in the example above would be defined as a
+    MetricUnit, as demonstrated below, allowing it to use all of the metric prefixes.
     """
 
     factor: Union[str, decimal.Decimal] = None
@@ -108,19 +111,36 @@ class Unit(AbstractUnit):
 
 @dataclasses.dataclass
 class MetricUnit(Unit):
-    """Like :class:`.Unit` but with metric prefixes like ``kilo`` for ``kilometre``."""
+    """Like :class:`.Unit` but with metric prefixes like ``kilo`` for ``kilometre``.
+
+    Usage::
+
+        from measurements.base import AbstractMeasure, Unit
+
+
+        class Distance(AbstractMeasure):
+            metre = MetricUnit(
+                "1", ["m", "meter", "Meter", "Metre"], ["m"], ["metre", "meter"]
+            )
+            inch = Unit("0.0254", ["in", "inches"])
+
+    In the example above, we update our simple distance measure to use MetricUnit
+    for the metric metre unit. As before, the first argument of a unit is it's SI
+    unit factor. For the SI unit itself – in this example metre – it's "1".
+
+    The second argument is a list of symbols, that are used to describe the unit.
+    Note that the attribute name itself, will also be added automatically to
+    the list of symbols.
+
+    The third argument is the small_metric_symbol, a List of symbols that are used
+    with single letter metric prefixes, such as ``m`` for ``km`` or ``μm``.
+
+    The fourth argument is metric_prefix, a list of symbols that are used with full
+    words metric prefixes, such as ``metre`` for ``kilometre``.
+    """
 
     small_metric_symbol: List[str] = dataclasses.field(default_factory=list)
-    """
-    List of symboles that are used with single letter metric prefixes,
-    such as ``m`` for ``km`` or ``μm``.
-    """
-
     metric_prefix: List[str] = dataclasses.field(default_factory=list)
-    """
-    List of symboles that are used with full words metric prefixes,
-    such as ``metre`` for ``kilometre``.
-    """
 
     SI_PREFIXE_SYMBOLS = {
         "y": decimal.Decimal("1e-24"),
@@ -306,7 +326,7 @@ class AbstractMeasure(metaclass=MeasureBase):
         return f'{qualname(self)}({self.unit.name}="{getattr(self, self.unit.name)}")'
 
     def __str__(self):
-        return "%s %s" % (getattr(self, self.unit.org_name), self.unit.org_name)
+        return f"{getattr(self, self.unit.org_name)} {self.unit.org_name}"
 
     def __format__(self, format_spec):
         decimal_format = getattr(self, self.unit.org_name).__format__(format_spec)
@@ -340,7 +360,7 @@ class AbstractMeasure(metaclass=MeasureBase):
     def __sub__(self, other):
         if not isinstance(other, type(self)):
             raise TypeError(
-                f"can't substract type '{qualname(other)}' from '{qualname(self)}'"
+                f"can't subtract type '{qualname(other)}' from '{qualname(self)}'"
             )
 
         return type(self)(
@@ -372,7 +392,7 @@ class AbstractMeasure(metaclass=MeasureBase):
             value = getattr(self, self.unit.org_name) / other
         except TypeError as e:
             raise TypeError(
-                f"can't devide type '{qualname(self)}' by '{qualname(other)}'"
+                f"can't divide type '{qualname(self)}' by '{qualname(other)}'"
             ) from e
         else:
             return type(self)(value=value, unit=self.unit.org_name)

--- a/measurement/base.py
+++ b/measurement/base.py
@@ -260,7 +260,7 @@ class AbstractMeasure(metaclass=MeasureBase):
         self.si_value = self.unit.to_si(value)
 
     def get_base_unit_names(self):
-        """Returns a list of unit names for units with a factor of 1 (base units)"""
+        """Return a list of unit names for units with a factor of 1 (base units)."""
         if getattr(self, "base_unit_names", None) is not None:
             return self.base_unit_names
 

--- a/measurement/base.py
+++ b/measurement/base.py
@@ -4,6 +4,7 @@ import dataclasses
 import decimal
 import inspect
 import warnings
+from decimal import Decimal
 from functools import total_ordering
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
@@ -257,6 +258,19 @@ class AbstractMeasure(metaclass=MeasureBase):
         self.unit = self._units[unit]
         self.unit.org_name = unit
         self.si_value = self.unit.to_si(value)
+
+    def get_base_unit_names(self):
+        """Returns a list of unit names for units with a factor of 1 (base units)"""
+        if getattr(self, "base_unit_names", None) is not None:
+            return self.base_unit_names
+
+        names_list = [
+            unit_name
+            for unit_name, unit in self._units.items()
+            if getattr(unit, "factor", None) is not None and unit.factor == Decimal("1")
+        ]
+        if names_list:
+            return names_list
 
     def __getattr__(self, name):
         try:

--- a/measurement/measures/electromagnetism.py
+++ b/measurement/measures/electromagnetism.py
@@ -42,9 +42,9 @@ class Inductance(AbstractMeasure):
 
 class ElectricPower(AbstractMeasure):
     """
-    Electric power can is defined as :class:`Voltage` multiplied by :class:`Current`.
+    Electric power is defined as :class:`Voltage` multiplied by :class:`Current`.
 
-    This is why you can devided :class:`Current` to get the :class:`Voltage`
+    This is why you can divide :class:`Current` to get the :class:`Voltage`
     by :class:`Voltage` to get the :class:`Current`
     or by :class:`Current` to get the :class:`Voltage`:
 

--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -8,24 +8,24 @@ __all__ = ["Distance", "Area", "Volume"]
 
 class Distance(AbstractMeasure):
     """
-    A distance the factor for both :class:`Area` and :class:`Volume`.
+    Distance is a factor for both :class:`Area` and :class:`Volume`.
 
     If you multiply a :class:`Distance` with another :class:`Distance`,
-    you will get an :class:`Area`:
+    you will get a :class:`Area`:
 
         >>> from measurement import measures
         >>> measures.Distance('2 m') * measures.Distance('3 m')
         Area(metre²="6")
 
-    If you multiply a :class:`Distance` with an :class:`Area` or two
-    :class:`Distances<Distance>`, you will get an :class:`Volume`:
+    If you multiply a :class:`Distance` with a :class:`Area` or two
+    :class:`Distances<Distance>`, you will get a :class:`Volume`:
 
         >>> from measurement import measures
         >>> measures.Distance('2 m') * measures.Area('6 m²')
         Volume(metre³="12")
 
-    You can also build the second and thrid power of a :class:`Distance`,
-    to get an :class:`Area` or :class:`Volume`.
+    You can also build the second and third power of a :class:`Distance`,
+    to get a :class:`Area` or :class:`Volume`.
 
         >>> from measurement import measures
         >>> measures.Distance('2 m') ** 2
@@ -112,8 +112,8 @@ class Area(AbstractMeasure, metaclass=AreaBase):
     """
     An area is defined as :class:`Distance` multipled by :class:`Distance`.
 
-    This is why you can multiple two :class:`Distances<Distance>` to get
-    an :class:`Area` or devide an :class:`Area` to get a :class:`Distance`:
+    This is why you can multiply two :class:`Distances<Distance>` to get
+    an :class:`Area` or divide an :class:`Area` to get a :class:`Distance`:
 
         >>> from measurement import measures
         >>> measures.Distance('2 m') * measures.Distance('3 m')
@@ -151,8 +151,10 @@ class Area(AbstractMeasure, metaclass=AreaBase):
 
     @classmethod
     def _attr_to_unit(cls, name):
-        if name[:3] == "sq_":
+        if name[:3] in ["sq_", "sq "]:
             name = f"{name[3:]}²"
+        elif name[:7] in ["square_", "square "]:
+            name = f"{name[7:]}²"
         return super()._attr_to_unit(name)
 
     def __truediv__(self, other):
@@ -189,9 +191,9 @@ class Volume(AbstractMeasure, metaclass=VolumeBase):
     """
     A volume is defined as :class:`Area` multipled by :class:`Distance`.
 
-    This is why you can multiple three :class:`Distances<Distance>` to get
-    a :class:`Volume`, multiple an :class:`Area` by a :class:`Distance`
-    or devide a :class:`Volume` by both :class:`Distance` and :class:`Area`:
+    This is why you can multiply three :class:`Distances<Distance>` to get
+    a :class:`Volume`, multiply a :class:`Area` by a :class:`Distance`
+    or divide a :class:`Volume` by both :class:`Distance` and :class:`Area`:
 
         >>> from measurement import measures
         >>> measures.Distance('2 m') * measures.Distance('3 m') * measures.Distance('4 m')

--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -137,7 +137,7 @@ class Area(AbstractMeasure, metaclass=AreaBase):
     ):
         # Maually setting the base unit, because the process of iterating through
         # all combinations for square/cubic/fractional measures is intense
-        self.base_unit_names = ['metre²', 'm²', 'meter²', 'Meter²', 'Metre²']
+        self.base_unit_names = ["metre²", "m²", "meter²", "Meter²", "Metre²"]
 
         return super().__init__(value, unit, **kwargs)
 
@@ -214,18 +214,18 @@ class Volume(AbstractMeasure, metaclass=VolumeBase):
         # Maually setting the base unit, because the process of iterating through
         # all combinations for square/cubic/fractional measures is intense
         self.base_unit_names = [
-            'kL',
-            'kl',
-            'kℓ',
-            'kilolitre',
-            'kiloliter',
-            'Kilolitre',
-            'Kiloliter',
-            'metre³',
-            'm³',
-            'meter³',
-            'Meter³',
-            'Metre³'
+            "kL",
+            "kl",
+            "kℓ",
+            "kilolitre",
+            "kiloliter",
+            "Kilolitre",
+            "Kiloliter",
+            "metre³",
+            "m³",
+            "meter³",
+            "Meter³",
+            "Metre³",
         ]
 
         return super().__init__(value, unit, **kwargs)

--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -1,4 +1,5 @@
 import decimal
+from typing import Optional, Union
 
 from measurement.base import AbstractMeasure, MeasureBase, MetricUnit, Unit
 
@@ -120,13 +121,25 @@ class Area(AbstractMeasure, metaclass=AreaBase):
         >>> measures.Area('6 m²') / measures.Distance('2 m')
         Distance(metre="3")
 
-    If if multiple an :class:`Area` with a :class:`Distance`,
+    If if multiply a :class:`Area` with a :class:`Distance`,
     you will get a :class:`Volume`:
 
         >>> measures.Area('6 m²') * measures.Distance('2 m')
         Volume(metre³="12")
 
     """
+
+    def __init__(
+        self,
+        value: Union[str, decimal.Decimal, int, None] = None,
+        unit: Optional[str] = None,
+        **kwargs: Union[str, decimal.Decimal, int, None],
+    ):
+        # Maually setting the base unit, because the process of iterating through
+        # all combinations for square/cubic/fractional measures is intense
+        self.base_unit_names = ['metre²', 'm²', 'meter²', 'Meter²', 'Metre²']
+
+        return super().__init__(value, unit, **kwargs)
 
     __factors__ = (Distance, Distance)
 
@@ -191,6 +204,31 @@ class Volume(AbstractMeasure, metaclass=VolumeBase):
         Area(metre²="2")
 
     """
+
+    def __init__(
+        self,
+        value: Union[str, decimal.Decimal, int, None] = None,
+        unit: Optional[str] = None,
+        **kwargs: Union[str, decimal.Decimal, int, None],
+    ):
+        # Maually setting the base unit, because the process of iterating through
+        # all combinations for square/cubic/fractional measures is intense
+        self.base_unit_names = [
+            'kL',
+            'kl',
+            'kℓ',
+            'kilolitre',
+            'kiloliter',
+            'Kilolitre',
+            'Kiloliter',
+            'metre³',
+            'm³',
+            'meter³',
+            'Meter³',
+            'Metre³'
+        ]
+
+        return super().__init__(value, unit, **kwargs)
 
     __factors__ = (Distance, Distance, Distance)
 

--- a/measurement/measures/mechanics.py
+++ b/measurement/measures/mechanics.py
@@ -1,4 +1,5 @@
 import decimal
+from typing import Optional, Union
 
 from measurement.base import AbstractMeasure, MeasureBase, MetricUnit, Unit
 
@@ -35,6 +36,70 @@ class FractionMeasureBase(MeasureBase):
 class VolumetricFlowRate(AbstractMeasure, metaclass=FractionMeasureBase):
     """Volumetric Flow measurements (generally for water flow)."""
 
+    def __init__(
+        self,
+        value: Union[str, decimal.Decimal, int, None] = None,
+        unit: Optional[str] = None,
+        **kwargs: Union[str, decimal.Decimal, int, None],
+    ):
+        # Maually setting the base unit, because the process of iterating through
+        # all combinations for square/cubic/fractional measures is intense
+        self.base_unit_names = [
+            "cms",
+            "cumecs",
+            "CMS",
+            "kL/second",
+            "kL/s",
+            "kL/sec",
+            "kL/seconds",
+            "kl/second",
+            "kl/s",
+            "kl/sec",
+            "kl/seconds",
+            "kℓ/second",
+            "kℓ/s",
+            "kℓ/sec",
+            "kℓ/seconds",
+            "kilolitre/second",
+            "kilolitre/s",
+            "kilolitre/sec",
+            "kilolitre/seconds",
+            "kiloliter/second",
+            "kiloliter/s",
+            "kiloliter/sec",
+            "kiloliter/seconds",
+            "Kilolitre/second",
+            "Kilolitre/s",
+            "Kilolitre/sec",
+            "Kilolitre/seconds",
+            "Kiloliter/second",
+            "Kiloliter/s",
+            "Kiloliter/sec",
+            "Kiloliter/seconds",
+            "metre³/second",
+            "metre³/s",
+            "metre³/sec",
+            "metre³/seconds",
+            "m³/second",
+            "m³/s",
+            "m³/sec",
+            "m³/seconds",
+            "meter³/second",
+            "meter³/s",
+            "meter³/sec",
+            "meter³/seconds",
+            "Meter³/second",
+            "Meter³/s",
+            "Meter³/sec",
+            "Meter³/seconds",
+            "Metre³/second",
+            "Metre³/s",
+            "Metre³/sec",
+            "Metre³/seconds",
+        ]
+
+        return super().__init__(value, unit, **kwargs)
+
     __numerator__ = Volume
     __denominator__ = Time
 
@@ -51,6 +116,39 @@ class VolumetricFlowRate(AbstractMeasure, metaclass=FractionMeasureBase):
 
 
 class Speed(AbstractMeasure, metaclass=FractionMeasureBase):
+    def __init__(
+        self,
+        value: Union[str, decimal.Decimal, int, None] = None,
+        unit: Optional[str] = None,
+        **kwargs: Union[str, decimal.Decimal, int, None],
+    ):
+        # Maually setting the base unit, because the process of iterating through
+        # all combinations for square/cubic/fractional measures is intense
+        self.base_unit_names = [
+            "metre/second",
+            "metre/s",
+            "metre/sec",
+            "metre/seconds",
+            "m/second",
+            "m/s",
+            "m/sec",
+            "m/seconds",
+            "meter/second",
+            "meter/s",
+            "meter/sec",
+            "meter/seconds",
+            "Meter/second",
+            "Meter/s",
+            "Meter/sec",
+            "Meter/seconds",
+            "Metre/second",
+            "Metre/s",
+            "Metre/sec",
+            "Metre/seconds",
+        ]
+
+        return super().__init__(value, unit, **kwargs)
+
     __numerator__ = Distance
     __denominator__ = Time
 

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -67,17 +67,17 @@ class TestDistance:
     def test_base_unit_names(self):
         one_mile = Distance(mi=1)
 
-        assert set(one_mile.get_base_unit_names()) == set(['metre', 'm', 'meter', 'Meter', 'Metre'])
+        assert set(one_mile.get_base_unit_names()) == set(
+            ["metre", "m", "meter", "Meter", "Metre"]
+        )
 
     def test_manual_base_unit_names(self):
-        from measurement.base import AbstractMeasure, Unit, MetricUnit
         from typing import Optional, Union
 
+        from measurement.base import AbstractMeasure, MetricUnit, Unit
 
         class SomeMeasure(AbstractMeasure):
-            abc = MetricUnit(
-                "1", ["ABC"], ["abc"], ["abc"]
-            )
+            abc = MetricUnit("1", ["ABC"], ["abc"], ["abc"])
             xyz = Unit("0.123", ["XYZ"])
 
             def __init__(
@@ -92,7 +92,7 @@ class TestDistance:
 
         some_measure = SomeMeasure(abc=12)
 
-        assert set(some_measure.get_base_unit_names()) == set(['abc', 'ABC'])
+        assert set(some_measure.get_base_unit_names()) == set(["abc", "ABC"])
 
 
 class TestArea:

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -59,6 +59,41 @@ class TestDistance:
         with pytest.raises(TypeError):
             Distance(m=1) ** 4
 
+    def test_unit_org_name(self):
+        one_mile = Distance(mi=1)
+
+        assert one_mile.unit.org_name == "mi"
+
+    def test_base_unit_names(self):
+        one_mile = Distance(mi=1)
+
+        assert set(one_mile.get_base_unit_names()) == set(['metre', 'm', 'meter', 'Meter', 'Metre'])
+
+    def test_manual_base_unit_names(self):
+        from measurement.base import AbstractMeasure, Unit, MetricUnit
+        from typing import Optional, Union
+
+
+        class SomeMeasure(AbstractMeasure):
+            abc = MetricUnit(
+                "1", ["ABC"], ["abc"], ["abc"]
+            )
+            xyz = Unit("0.123", ["XYZ"])
+
+            def __init__(
+                self,
+                value: Union[str, decimal.Decimal, int, None] = None,
+                unit: Optional[str] = None,
+                **kwargs: Union[str, decimal.Decimal, int, None],
+            ):
+                self.base_unit_names = ["abc", "ABC"]
+
+                return super().__init__(value, unit, **kwargs)
+
+        some_measure = SomeMeasure(abc=12)
+
+        assert set(some_measure.get_base_unit_names()) == set(['abc', 'ABC'])
+
 
 class TestArea:
     def test_truediv(self):

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -110,6 +110,9 @@ class TestArea:
 
     def test_attr_to_unit(self):
         assert Area._attr_to_unit("sq_m") == "m²"
+        assert Area._attr_to_unit("sq m") == "m²"
+        assert Area._attr_to_unit("square_m") == "m²"
+        assert Area._attr_to_unit("square m") == "m²"
         assert Area._attr_to_unit("m²") == "m²"
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -88,6 +88,10 @@ class TestAbstractMeasure:
     def test_format(self):
         assert f"{Distance('1 km') / 3:5.3f}" == "0.333 km"
         assert f"{Distance(km=1/3):5.3f}" == "0.333 km"
+        assert (
+            f"{Distance(km=decimal.Decimal('1')/decimal.Decimal('3')):5.3f}"
+            == "0.333 km"
+        )
         with pytest.raises(ValueError):
             f"{Distance('1 km') / 3:5.3x}"
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -150,8 +150,7 @@ class TestAbstractMeasure:
         with pytest.raises(TypeError) as e:
             self.measure(**{self.unit: 2}) - "not-allowed"
         assert (
-            str(e.value)
-            == f"can't substract type 'str' from '{qualname(self.measure)}'"
+            str(e.value) == f"can't subtract type 'str' from '{qualname(self.measure)}'"
         )
 
     def test_isub(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -192,7 +192,7 @@ class TestAbstractMeasure:
     def test_truediv__raise__type_error(self):
         with pytest.raises(TypeError) as e:
             self.measure(**{self.unit: 2}) / "not-allowed"
-        assert str(e.value) == f"can't devide type '{qualname(self.measure)}' by 'str'"
+        assert str(e.value) == f"can't divide type '{qualname(self.measure)}' by 'str'"
 
     def test_itruediv(self):
         d = self.measure(**{self.unit: 2})


### PR DESCRIPTION
**Improved docstrings and other strings**
- Corrected spelling/grammar
- Added additional context

**Added method (and tests) to get a measure's base unit (or set manually)**
There was no clear way to determine the base unit for a measure. For instance, the base unit of Volume is `cubic_m (and all its name variations).

The `get_base_unit_names()` method of `AbstractMeasure` returns a list of all the names associated with the base unit (the unit where factor = "1").

It starts by checking if a base unit was manually specified with `self.base_unit_names`. For simple measures which aren't factors or multiples of other measures, this is a quick process.

For more complex measures, if we don't set these values manually we must iterate through dozens or hundreds of possible combinations of measures. For instance, the Volume units can be made from combinations of Distance, Area, and Volume. Instead of iterating through every one of these combinations, I manually set the value for the base unit names when they are factors or fractions of other measures.

If `self.base_unit_names` is _not_ manually set for the measure, the method then iterates through all possible unit names for the measure where factor="1", and returns the resulting list.

Purpose: Being able to identify the base unit for any particular measure is something that was missing. This method will allow a fallback default value for forms in the accompanying project, django-measurement, as well as other possibilities in the future.

**Minor update to allow `square_` in addition to `sq_`**