### PR TITLE
Minor update to allow `square_` in addition to `sq_`  (cherry-picked from previous PR)

### DIFF
--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -138,8 +138,10 @@ class Area(AbstractMeasure, metaclass=AreaBase):
 
     @classmethod
     def _attr_to_unit(cls, name):
-        if name[:3] == "sq_":
+        if name[:3] in ["sq_", "sq "]:
             name = f"{name[3:]}²"
+        elif name[:7] in ["square_", "square "]:
+            name = f"{name[7:]}²"
         return super()._attr_to_unit(name)
 
     def __truediv__(self, other):

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -75,6 +75,9 @@ class TestArea:
 
     def test_attr_to_unit(self):
         assert Area._attr_to_unit("sq_m") == "m²"
+        assert Area._attr_to_unit("sq m") == "m²"
+        assert Area._attr_to_unit("square_m") == "m²"
+        assert Area._attr_to_unit("square m") == "m²"
         assert Area._attr_to_unit("m²") == "m²"
 
 


### PR DESCRIPTION
Cubic measurements use the entire word `cubic_` or `cubic `, but square only allows `sq_` or `sq `.

This small PR updates to allow `square_` and `square ` for consistence, without removing previous functionality.