### PR TITLE
Added the get_base_unit_names() classmethod

### DIFF
--- a/measurement/base.py
+++ b/measurement/base.py
@@ -277,6 +277,20 @@ class AbstractMeasure(metaclass=MeasureBase):
         self.unit = self._units[unit]
         self.unit.org_name = unit
         self.si_value = self.unit.to_si(value)
+        self.base_unit_names = self.get_base_unit_names()
+
+    @classmethod
+    def get_base_unit_names(cls):
+        """Return a list of unit names for units with a factor of 1 (base units)."""
+
+        names_list = [
+            unit_name
+            for unit_name, unit in cls._units.items()
+            if getattr(unit, "factor", None) is not None
+            and unit.factor == decimal.Decimal("1")
+        ]
+        if names_list:
+            return names_list
 
     def __getattr__(self, name):
         try:

--- a/measurement/base.py
+++ b/measurement/base.py
@@ -282,7 +282,6 @@ class AbstractMeasure(metaclass=MeasureBase):
     @classmethod
     def get_base_unit_names(cls):
         """Return a list of unit names for units with a factor of 1 (base units)."""
-
         names_list = [
             unit_name
             for unit_name, unit in cls._units.items()

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -59,6 +59,30 @@ class TestDistance:
         with pytest.raises(TypeError):
             Distance(m=1) ** 4
 
+    def test_unit_org_name(self):
+        one_mile = Distance(mi=1)
+
+        assert one_mile.unit.org_name == "mi"
+
+    def test_base_unit_names(self):
+        one_mile = Distance(mi=1)
+
+        assert set(one_mile.base_unit_names) == set(
+            ["metre", "m", "meter", "Meter", "Metre"]
+        )
+
+    def test_get_base_unit_names_for_instance(self):
+        one_mile = Distance(mi=1)
+
+        assert set(one_mile.get_base_unit_names()) == set(
+            ["metre", "m", "meter", "Meter", "Metre"]
+        )
+
+    def test_get_base_unit_names_for_class(self):
+        assert set(Distance.get_base_unit_names()) == set(
+            ["metre", "m", "meter", "Meter", "Metre"]
+        )
+
 
 class TestArea:
     def test_truediv(self):


### PR DESCRIPTION
(It was easier to close the previous PR and submit this cleaned-up, simplified version)

Also sets the `self.base_unit_names` property

There was no clear way to determine the base unit for a measure. For instance, the base unit of Volume is `cubic_m (and all its name variations).

The get_base_unit_names() method of AbstractMeasure returns a list of all the names associated with the base unit (the unit where factor = "1").

Purpose: Being able to identify the base unit for any particular measure is something that was missing. This method will allow a fallback default value for forms in the accompanying project, django-measurement, as well as other possibilities in the future.