### PR TITLE
Add point as distance unit

### DIFF
--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -71,6 +71,7 @@ class Distance(AbstractMeasure):
     sears_yard = Unit("0.91439841", ["sears_yd", "Yard (Sears"])
     survey_foot = Unit("0.304800609601", ["survey_ft", "US survey foot", "U.S. Foot"])
     yard = Unit("0.9144", ["yd"])
+    point = Unit(decimal.Decimal("25.4e-3") / 72, ["pt"])
 
     def __mul__(self, other):
         if isinstance(other, Distance):

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -83,6 +83,12 @@ class TestDistance:
             ["metre", "m", "meter", "Meter", "Metre"]
         )
 
+    def test_point(self):
+        assert Distance(inch=3).mm == pytest.approx(Distance(pt=3 * 72).mm)
+        assert Distance(inch=decimal.Decimal("8") / 72).mm == pytest.approx(
+            Distance(pt=8).mm
+        )
+
 
 class TestArea:
     def test_truediv(self):


### PR DESCRIPTION
In typography [points](https://en.wikipedia.org/wiki/Point_(typography)) are a standard unit of measure and are equal to 1/72 of an inch or ca. 0.3528mm. The Portable Document Format (PDF) also specifies its standard coordinate system in 1/72 inch (PDF 32000-1:2008, section 8.3.2.3).