### PR TITLE
Fix: Improve list of runtime requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - run: sudo apt-get install -y graphviz
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      - run: python -m pip install pip setuptools wheel
+      - run: python -m pip install pip setuptools wheel sphinx python-docs-theme
       - run: python setup.py develop
       - run: python setup.py build_sphinx -W
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib/
 docs/_build/
 .coverage
 htmlcov/
+.venv*

--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -103,7 +103,7 @@ class AreaBase(MeasureBase):
     @staticmethod
     def square(klass):
         for name, unit in klass._units.items():
-            qs_unit = Unit(factor=unit.factor ** 2)
+            qs_unit = Unit(factor=unit.factor**2)
             qs_unit.name = f"{qs_unit.name}²"
             yield f"{name}²", qs_unit
 
@@ -170,7 +170,7 @@ class VolumeBase(MeasureBase):
     @staticmethod
     def cubic(klass):
         for name, unit in klass._units.items():
-            qs_unit = Unit(factor=unit.factor ** 3)
+            qs_unit = Unit(factor=unit.factor**3)
             qs_unit.name = f"{qs_unit.name}³"
             yield f"{name}³", qs_unit
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,12 +37,10 @@ python_requires = '>=3.7'
 packages = find:
 setup_requires =
     setuptools_scm
-    sphinx
-    python-docs-theme
-    pytest-runner
 tests_require =
     pytest
     pytest-cov
+    pytest-runner
 
 [options.packages.find]
 exclude =

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -35,7 +35,7 @@ class TestDistance:
 
         micrometers = one_meter.um
 
-        assert one_meter.si_value * 10 ** 6 == micrometers
+        assert one_meter.si_value * 10**6 == micrometers
 
     def test_area_sq_km(self):
         one_sq_km = Area(sq_km=10)


### PR DESCRIPTION
Dear Adam,

first things first: Thanks a stack for conceiving and maintaining this excellent package. We are using it in [Wetterdienst] and you might love to hear about it.

This patch tries to improve the situation with #70 by adjusting the designated dependencies.

- _Sphinx_ and the _Python Docs Sphinx Theme_ are now only pulled in by the GHA CI job for building the documentation.
- The dependency on `pytest-runner` moved to the `tests_require` section.

I think both adjustments should be fine and decrease the footprint of what will get installed on downstream machines/projects when installing or pulling in this package. Please let me know if you have any objections on it.

Keep up the spirit and with kind regards,
Andreas.

/cc @gutzbenj

[Wetterdienst]: https://github.com/earthobservations/wetterdienst
