### PR TITLE
move doc-requirements to docs/requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
       - run: python -m pip install pip setuptools wheel
+      - run: python -m pip install -r docs/requirements.txt
       - run: python setup.py develop
       - run: python setup.py build_sphinx -W
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinxcontrib.applehelp==1.0.2
+sphinx==6.1.2
+python-docs-theme==2022.1

--- a/measurement/measures/geometry.py
+++ b/measurement/measures/geometry.py
@@ -103,7 +103,7 @@ class AreaBase(MeasureBase):
     @staticmethod
     def square(klass):
         for name, unit in klass._units.items():
-            qs_unit = Unit(factor=unit.factor ** 2)
+            qs_unit = Unit(factor=unit.factor**2)
             qs_unit.name = f"{qs_unit.name}²"
             yield f"{name}²", qs_unit
 
@@ -170,7 +170,7 @@ class VolumeBase(MeasureBase):
     @staticmethod
     def cubic(klass):
         for name, unit in klass._units.items():
-            qs_unit = Unit(factor=unit.factor ** 3)
+            qs_unit = Unit(factor=unit.factor**3)
             qs_unit.name = f"{qs_unit.name}³"
             yield f"{name}³", qs_unit
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,7 @@ python_requires = '>=3.7'
 packages = find:
 setup_requires =
     setuptools_scm
-    sphinx
-    python-docs-theme
-    pytest-runner
+    pytest_runner
 tests_require =
     pytest
     pytest-cov

--- a/tests/measures/test_geometry.py
+++ b/tests/measures/test_geometry.py
@@ -35,7 +35,7 @@ class TestDistance:
 
         micrometers = one_meter.um
 
-        assert one_meter.si_value * 10 ** 6 == micrometers
+        assert one_meter.si_value * 10**6 == micrometers
 
     def test_area_sq_km(self):
         one_sq_km = Area(sq_km=10)


### PR DESCRIPTION
This moves the sphinx requirements into `docs/requirements.txt` for our doc-build process & readthedocs to use. 

This definitely helps with #75 only in that matter that it doesn't break production builds any more.

it doesn't fix the originating issue, only moves it to the doc-build. 

I provided specific versions for in `docs/requirements.txt`, as recommended by readthedocs. I'm hoping that freezing `sphinxcontrib.applehelp` here helps with fixing this for the doc-build, we'll see when CI passed & how readthedocs handles this. 